### PR TITLE
Fix iOS build issue

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.24" />
+    <option name="version" value="1.9.23" />
   </component>
 </project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,14 @@
 [versions]
 agp = "8.2.2"
-kotlin = "1.9.24"
-compose = "1.6.7"
-compose-material3 = "1.2.1"
+kotlin = "1.9.23"
+redwood = "0.10.0"
+
+jbCompose = "1.6.2"
+
 androidx-activityCompose = "1.9.0"
 
 kotlinx-coroutines = "1.8.1"
 kotlinx-serialization = "1.6.3"
-
-jbCompose = "1.6.2"
-
-redwood = "0.11.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -34,7 +32,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 
 google-material = { module = "com.google.android.material:material", version = "1.12.0" }
 
-jetbrains-compose-compiler = "org.jetbrains.compose.compiler:compiler:1.5.14"
+jetbrains-compose-compiler = "org.jetbrains.compose.compiler:compiler:1.5.13.2"
 jetbrains-compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "jbCompose" }
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "jbCompose" }
 jetbrains-compose-material = { module = "org.jetbrains.compose.material:material", version.ref = "jbCompose" }

--- a/samples/counter/desktop-composeui/build.gradle
+++ b/samples/counter/desktop-composeui/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.compose'
 
 compose {
-  kotlinCompilerPlugin.set("org.jetbrains.compose.compiler:compiler:1.5.14") // kotlin 1.9.24
+  kotlinCompilerPlugin.set("org.jetbrains.compose.compiler:compiler:1.5.13.2") // kotlin 1.9.23
   desktop {
     application {
       mainClass = "com.example.redwood.counter.desktop.Main"


### PR DESCRIPTION
```
# This is needed for the JB Compose runtime to link on native targets. They also use this flag
# in their samples. Over time it should be removed once they figure out why it was needed.
kotlin.native.cacheKind=none
```